### PR TITLE
feat: implement pedro block

### DIFF
--- a/blocks/pedro/pedro.css
+++ b/blocks/pedro/pedro.css
@@ -1,0 +1,39 @@
+/* Mobile-first (default) — stacked: body on top, image below */
+.pedro .pedro-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.pedro .pedro-image img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+.pedro .pedro-body h2 {
+  font-family: var(--heading-font-family);
+  font-size: var(--heading-font-size-l);
+  margin: 0 0 0.5rem;
+}
+
+.pedro .pedro-description {
+  font-size: var(--body-font-size-m);
+  color: var(--dark-color);
+}
+
+/* Desktop — text left, image right */
+@media (width >= 900px) {
+  .pedro .pedro-content {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .pedro .pedro-body {
+    flex: 1;
+  }
+
+  .pedro .pedro-image {
+    flex: 1;
+  }
+}

--- a/blocks/pedro/pedro.js
+++ b/blocks/pedro/pedro.js
@@ -1,0 +1,49 @@
+import { moveInstrumentation } from '../../scripts/scripts.js';
+
+/**
+ * @param {Element} block The pedro block element
+ */
+export default async function decorate(block) {
+  const rows = [...block.children];
+
+  // Row 0: image (reference + alt collapsed into one row)
+  const picture = rows[0]?.querySelector('picture');
+
+  // Row 1: title (text field — plain text)
+  const titleText = rows[1]?.textContent?.trim();
+
+  // Row 2: description (richtext field — HTML preserved)
+  const descriptionHTML = rows[2]?.querySelector('div')?.innerHTML;
+
+  // Build semantic structure
+  const content = document.createElement('div');
+  content.className = 'pedro-content';
+
+  const body = document.createElement('div');
+  body.className = 'pedro-body';
+
+  if (titleText) {
+    const h2 = document.createElement('h2');
+    h2.textContent = titleText;
+    body.append(h2);
+  }
+
+  if (descriptionHTML) {
+    const desc = document.createElement('div');
+    desc.className = 'pedro-description';
+    desc.innerHTML = descriptionHTML;
+    body.append(desc);
+  }
+
+  content.append(body);
+
+  if (picture) {
+    const imageWrapper = document.createElement('div');
+    imageWrapper.className = 'pedro-image';
+    moveInstrumentation(rows[0], imageWrapper);
+    imageWrapper.append(picture);
+    content.append(imageWrapper);
+  }
+
+  block.replaceChildren(content);
+}


### PR DESCRIPTION
## Summary

Implements the pedro block with a text-left / image-right layout.

Closes #23

## Preview

https://feat-pedro-impl--eaxwalkbr--eliasaugusto.aem.page/pt-br

## Changes

- `blocks/pedro/pedro.js` — Block decoration: extracts image, title, and description rows; builds semantic HTML with body (h2 + rich text) on the left and image on the right. Uses `moveInstrumentation()` for Universal Editor compatibility.
- `blocks/pedro/pedro.css` — Mobile-first responsive styles: stacked on mobile, side-by-side (text left, image right) on desktop (≥900px).

## Acceptance Criteria

- [x] Block renders with text on the left, image on the right (desktop)
- [x] Mobile-first: stacks vertically on small screens
- [x] Uses `moveInstrumentation()` for UE compatibility
- [x] Passes `npm run lint`